### PR TITLE
triton-cns#14 CNS should always publish names for poseidon

### DIFF
--- a/lib/flag-filter.js
+++ b/lib/flag-filter.js
@@ -190,7 +190,7 @@ FlagFilter.prototype._transform = function (vm, enc, cb) {
 	 */
 	if ((vm.owner.login === 'admin' || vm.owner.login === 'poseidon') &&
 	    vm.services.length > 0) {
-		    vm.listInstance = true;
+		vm.listInstance = true;
 	        vm.listServices = true;
 	        vm.reasons.push(vm.owner.login);
 	}

--- a/lib/flag-filter.js
+++ b/lib/flag-filter.js
@@ -189,10 +189,10 @@ FlagFilter.prototype._transform = function (vm, enc, cb) {
 	 * attached. 
 	 */
 	if ((vm.owner.login === 'admin' || vm.owner.login === 'poseidon')
-		&& vm.services.length > 0) {
-		vm.listInstance = true;
-		vm.listServices = true;
-		vm.reasons.push(vm.owner.login);
+	    && vm.services.length > 0) {
+	    vm.listInstance = true;
+	    vm.listServices = true;
+	    vm.reasons.push(vm.owner.login);
 	}
 
 	/*

--- a/lib/flag-filter.js
+++ b/lib/flag-filter.js
@@ -185,7 +185,7 @@ FlagFilter.prototype._transform = function (vm, enc, cb) {
 	}
 
 	/* 
-	 * And enable VMs owned by admin and poseidon that have a service 
+	 * And enable VMs owned by admin or poseidon that have a service 
 	 * attached. 
 	 */
 	if ((vm.owner.login === 'admin' || vm.owner.login === 'poseidon')

--- a/lib/flag-filter.js
+++ b/lib/flag-filter.js
@@ -192,7 +192,7 @@ FlagFilter.prototype._transform = function (vm, enc, cb) {
 		&& vm.services.length > 0) {
 		vm.listInstance = true;
 		vm.listServices = true;
-		vm.reasons.push('admin');
+		vm.reasons.push(vm.owner.login);
 	}
 
 	/*

--- a/lib/flag-filter.js
+++ b/lib/flag-filter.js
@@ -184,8 +184,12 @@ FlagFilter.prototype._transform = function (vm, enc, cb) {
 		vm.ptrname = vm.tags[DOCKER_PREFIX + INST_PTR_TAG];
 	}
 
-	/* And enable VMs owned by admin that have a service attached. */
-	if (vm.owner.login === 'admin' && vm.services.length > 0) {
+	/* 
+	 * And enable VMs owned by admin and poseidon that have a service 
+	 * attached. 
+	 */
+	if ((vm.owner.login === 'admin' || vm.owner.login === 'poseidon')
+		&& vm.services.length > 0) {
 		vm.listInstance = true;
 		vm.listServices = true;
 		vm.reasons.push('admin');

--- a/lib/flag-filter.js
+++ b/lib/flag-filter.js
@@ -184,9 +184,9 @@ FlagFilter.prototype._transform = function (vm, enc, cb) {
 		vm.ptrname = vm.tags[DOCKER_PREFIX + INST_PTR_TAG];
 	}
 
-	/* 
-	 * And enable VMs owned by admin or poseidon that have a service 
-	 * attached. 
+	/*
+	 * And enable VMs owned by admin or poseidon that have a service
+	 * attached.
 	 */
 	if ((vm.owner.login === 'admin' || vm.owner.login === 'poseidon')
 	    && vm.services.length > 0) {

--- a/lib/flag-filter.js
+++ b/lib/flag-filter.js
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) 2015, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 module.exports = FlagFilter;
@@ -188,11 +188,11 @@ FlagFilter.prototype._transform = function (vm, enc, cb) {
 	 * And enable VMs owned by admin or poseidon that have a service
 	 * attached.
 	 */
-	if ((vm.owner.login === 'admin' || vm.owner.login === 'poseidon')
-	    && vm.services.length > 0) {
-	    vm.listInstance = true;
-	    vm.listServices = true;
-	    vm.reasons.push(vm.owner.login);
+	if ((vm.owner.login === 'admin' || vm.owner.login === 'poseidon') &&
+	    vm.services.length > 0) {
+		    vm.listInstance = true;
+	        vm.listServices = true;
+	        vm.reasons.push(vm.owner.login);
 	}
 
 	/*


### PR DESCRIPTION
Always publish names for white-listed instances owned by user `poseidon` as is done for user `admin` today.